### PR TITLE
Images alongside teaser text

### DIFF
--- a/data/accidentalProphetStory.xml
+++ b/data/accidentalProphetStory.xml
@@ -4,8 +4,7 @@
 	<!--  Apprentice satellites -->
 
 		<storyNode id="introduceApprentice" type="satellite" lastNode="false">
-			<teaserText>A young man approaches with a certain eagerness in his eyes.</teaserText>
-			<eventText>He asks you for your advice on a few existential questions before a long pause. He looks up at you pensively. "I've been reading your teachings and listening to you speak, Prophet, and I would like to live my life in service to you and the deity."
+			<teaserText>A young man approaches with a certain eagerness in his eyes.</teaserText><eventText>He asks you for your advice on a few existential questions before a long pause. He looks up at you pensively. "I've been reading your teachings and listening to you speak, Prophet, and I would like to live my life in service to you and the deity."
 
 The devotion he shows gives you renewed faith in your cause. You agree to take him under your wing.</eventText>
 			<functionalDescription>
@@ -19,7 +18,7 @@ The devotion he shows gives you renewed faith in your cause. You agree to take h
 					<quantModifier id="charityMetric" absolute="false">+1</quantModifier>
 				</outcome>
 			</choice>
-			<teaserImage>../data/images/wealth.png</teaserImage></storyNode>
+			</storyNode>
 
 		<storyNode id="apprenticeOutskirts" type="satellite" lastNode="false">
 			<teaserText>Your apprentice return after sending him to the outskirts earlier that day.</teaserText>
@@ -71,8 +70,7 @@ The devotion he shows gives you renewed faith in your cause. You agree to take h
 
 
 		<storyNode id="apprenticeInPast" type="satellite">
-			<teaserText>Your apprentice approaches, lost in the past.</teaserText>
-			<eventText>He is sitting close by, but looks a million miles away.
+			<teaserText>Your apprentice approaches, lost in the past.</teaserText><eventText>He is sitting close by, but looks a million miles away.
 
 "What troubles you so, young man?"
 
@@ -90,7 +88,7 @@ He says nothing, but subconsciously fingers the scar on his forearm.
 					<quantModifier id="trustMetric" absolute="false">+1</quantModifier>
 				</outcome>
 			</choice>
-                        <teaserImage>../data/images/wealth.png</teaserImage>
+                        
 		</storyNode>
 
 

--- a/data/accidentalProphetStory.xml
+++ b/data/accidentalProphetStory.xml
@@ -1,8 +1,8 @@
 <story numTopScenesForUser="3" prioritizationType="eventBased">
 	<storyNodes>
-	
+
 	<!--  Apprentice satellites -->
-	
+
 		<storyNode id="introduceApprentice" type="satellite" lastNode="false">
 			<teaserText>A young man approaches with a certain eagerness in his eyes.</teaserText>
 			<eventText>He asks you for your advice on a few existential questions before a long pause. He looks up at you pensively. "I've been reading your teachings and listening to you speak, Prophet, and I would like to live my life in service to you and the deity."
@@ -19,8 +19,8 @@ The devotion he shows gives you renewed faith in your cause. You agree to take h
 					<quantModifier id="charityMetric" absolute="false">+1</quantModifier>
 				</outcome>
 			</choice>
-		</storyNode>
-		
+			<teaserImage>../data/images/wealth.png</teaserImage></storyNode>
+
 		<storyNode id="apprenticeOutskirts" type="satellite" lastNode="false">
 			<teaserText>Your apprentice return after sending him to the outskirts earlier that day.</teaserText>
 			<eventText>Despite the short time away, he looks older and wiser from his time in lower town. His robe is tattered and his face is coated with grime beyond the usual daily wear. He describes to you a strong group of skeptics who spat at and ridiculed him.</eventText>
@@ -48,9 +48,10 @@ The devotion he shows gives you renewed faith in your cause. You agree to take h
 					<quantModifier id="charityMetric" absolute="false">-1</quantModifier>
 				</outcome>
 			</choice>
+                        <teaserImage>../data/images/wealth.png </teaserImage>
 		</storyNode>
-		
-		<!-- 
+
+		<!--
 		<storyNode id="" type="satellite">
 			<teaserText></teaserText>
 			<eventText></eventText>
@@ -67,12 +68,12 @@ The devotion he shows gives you renewed faith in your cause. You agree to take h
 			</choice>
 		</storyNode>
 		 -->
-		
-		
+
+
 		<storyNode id="apprenticeInPast" type="satellite">
 			<teaserText>Your apprentice approaches, lost in the past.</teaserText>
 			<eventText>He is sitting close by, but looks a million miles away.
-			
+
 "What troubles you so, young man?"
 
 He says nothing, but subconsciously fingers the scar on his forearm.
@@ -89,9 +90,10 @@ He says nothing, but subconsciously fingers the scar on his forearm.
 					<quantModifier id="trustMetric" absolute="false">+1</quantModifier>
 				</outcome>
 			</choice>
+                        <teaserImage>../data/images/wealth.png</teaserImage>
 		</storyNode>
-		
-		
+
+
 		<storyNode id="apprenticePubScars" type="satellite">
 			<teaserText>You wander over to the public house to see who might need help over a quick drink.</teaserText>
 			<eventText>While enjoying a pint of your favorite drink, you happen to overhear your apprentice's name float into the din.
@@ -126,18 +128,18 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
-		
+
+
 		<!-- Blacksmith satellites -->
-		
+
 		<storyNode id="holySymbol1" type="satellite" lastNode="false">
          	<teaserText>The town blacksmith comes to you with an interesting proposal...</teaserText>
          	<eventText> The blacksmith stands before you, twisting his beard in excitement. He's hoping that you can fund the creation of ornate metal-worked holy symbols for your burgeoning 	faith. </eventText>
          	<functionalDescription>
-				<prominence id="wealthTheme">1</prominence>	        
+				<prominence id="wealthTheme">1</prominence>
 			</functionalDescription>
 	        <prerequisite>
-	            <quantReq id="wealthMetric" operator="greaterThan" compareTo="1"/>         
+	            <quantReq id="wealthMetric" operator="greaterThan" compareTo="1"/>
 	        </prerequisite>
 	        <choice>
 	            <text>Grant him the funds!</text>
@@ -154,7 +156,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 	            </outcome>
 	        </choice>
 	    </storyNode>
-		
+
 		<storyNode id="crowOmen" type="satellite" lastNode="false">
 			<teaserText>One of the villagers wants to inform you of a strange happening...</teaserText>
 			<eventText>Ulrich said the black crow was lucky, I saw one last night and now my crops are dead.</eventText>
@@ -170,16 +172,16 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
+
 		<storyNode id="holySymbol2" type="satellite" lastNode="false">
          	<teaserText>The blacksmith hopes you will reconsider his offer...</teaserText>
          	<eventText> The blacksmith once again comes before you with renewed vigour. He really thinks you should take advantage of his offer to create your holy symbols, and is willing to work at half his original fee </eventText>
          	<functionalDescription>
-				<prominence id="wealthTheme">1</prominence>	        
+				<prominence id="wealthTheme">1</prominence>
 			</functionalDescription>
 	        <prerequisite>
 	            <quantReq id="wealthMetric" operator="greaterThan" compareTo="1"/>
-	            <sceneReq name="holySymbol1" operator="seen"/>         
+	            <sceneReq name="holySymbol1" operator="seen"/>
 	        </prerequisite>
 	        <choice>
 	            <text>Grant him the funds!</text>
@@ -202,12 +204,12 @@ They share an uproarious laugh over what they imagined got him into that state.<
          	<eventText>The blacksmith is wondering what exactly you had in mind for the holy symbols-- which of these designs best suit your faith?' visual design. What should they look like? </eventText>
 			<functionalDescription>
 				<prominence id="trustTheme">1</prominence>
-				<prominence id="superstitionTheme">1</prominence>	            
+				<prominence id="superstitionTheme">1</prominence>
 			</functionalDescription>
 	        <prerequisite>
 	        	<tagReq id="paidBlacksmith" operator="contains" />
 	        </prerequisite>
-	        
+
 	        <choice>
 	            <text>Jagged and brutal.</text>
 	            <outcome>
@@ -230,10 +232,10 @@ They share an uproarious laugh over what they imagined got him into that state.<
 	            </outcome>
 	        </choice>
 	    </storyNode>
-		
-		
+
+
 		<!-- Shepherd satellites -->
-		
+
 		<storyNode id="shepFlockBirth" type="satellite" lastNode="false">
 			<teaserText>A happy occurence is cause for consecration...</teaserText>
 			<eventText>Shepard has had a new lamb born and wants you to come over the consecrate the flock.</eventText>
@@ -258,10 +260,10 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
-		
+
+
 		<!-- Butcher satellites -->
-		
+
 		<storyNode id="badMeatMeet" type="satellite" lastNode="false">
 			<teaserText>A chance to increase your wealth approaches, but at a cost.</teaserText>
 			<eventText>Butcher has a problem with people getting sick from his meat, and wants you to tell them they’re not living a moral enough life</eventText>
@@ -287,10 +289,10 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
-		
+
+
 		<!-- Witch satellites -->
-		
+
 		<storyNode id="witchVisit" type="satellite" lastNode="false">
 			<teaserText>Amice, a so-called witch who lives on the outskirts of town, has ventured in to seek your aid.</teaserText>
 			<eventText>Her robes have been torn in spots, and appear to be freshly smattered with rotten fruit during her journey in. She explains that she’s come to seek your company across the other half of the town and to the marshes where she wishes to collect moss for her craft.</eventText>
@@ -314,10 +316,10 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
-		
+
+
 		<!-- Mother satellites -->
-		
+
 		<storyNode id="motherVisit" type="satellite" lastNode="false">
 			<teaserText>A villager desperate for your help arrives.</teaserText>
 			<eventText>The mother wants to have a baby, asks for ingredient for fertility. She does not have the coin to buy it herself and is appealing to your good nature.</eventText>
@@ -348,13 +350,13 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-		
+
 		<storyNode id="holySymbol4" type="satellite" lastNode="false">
          	<teaserText>A grieving mother seeks your aid...</teaserText>
          	<eventText>The miller's wife is quite distraught over the violent and unexpected death of her son. Upon investigation of the grisly scene, you notice the dead boy is clutching a bloody symbol of devotion to your faith in his lifeless fingers.</eventText>
 			<functionalDescription>
 				<prominence id="trustTheme">1</prominence>
-				<prominence id="superstitionTheme">1</prominence>	            
+				<prominence id="superstitionTheme">1</prominence>
 			</functionalDescription>
 	        <prerequisite>
 	        	<tagReq id="jaggedSymbol" operator="contains" />
@@ -364,12 +366,12 @@ They share an uproarious laugh over what they imagined got him into that state.<
 	            	<quantModifier id="superstitionMetric" absolute="false">+3</quantModifier>
 	            	<quantModifier id="trustMetric" absolute="false">-2</quantModifier>
 	            </outcome>
-	        </choice>        
+	        </choice>
 	    </storyNode>
-		
-		
+
+
 		<!-- General pool of villagers satellites -->
-	
+
 		<storyNode id="drunkWalk" type="satellite" lastNode="false">
 			<teaserText>Take some time to walk among the people.</teaserText>
 			<eventText>Walking along you pass the village drunk passed out naked in the street. Do you leave him or take him in?</eventText>
@@ -394,7 +396,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				</outcome>
 			</choice>
 		</storyNode>
-	
+
 		<storyNode id="basementMystery" type="satellite" lastNode="false">
 			<teaserText>A very distressed villager arrives</teaserText>
 			<eventText>You are approached by someone fearful of a fiend in their basement, you investigate and wake up suddenly somewhere in the woods</eventText>
@@ -402,7 +404,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				<prominence id="insanityTheme">1</prominence>
 			</functionalDescription>
 		</storyNode>
-	
+
 		<storyNode id="skyMystery" type="satellite" lastNode="false">
 			<teaserText>A very distressed villager arrives.</teaserText>
 			<eventText>Farmer finds meteor in field, they need you to go investigate the meaning of it.</eventText>
@@ -410,7 +412,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				<prominence id="insanityTheme">1</prominence>
 			</functionalDescription>
 		</storyNode>
-		
+
 		<storyNode id="interruptMystery" type="satellite" lastNode="false">
 			<teaserText>You feel disconnected from the petitions today, something else is on your mind...</teaserText>
 			<eventText>As a noble from a nearby town confides in you, you are suddenly overcome and interrupt them ranting about the state of the stars and the great tragedy that is your existence.</eventText>
@@ -418,7 +420,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				<prominence id="insanityTheme">3</prominence>
 			</functionalDescription>
 		</storyNode>
-		
+
 		<storyNode id="whisperMystery" type="satellite" lastNode="false">
 			<teaserText>A deep paranoia has followed you from your sleep...</teaserText>
 			<eventText>The town baker just wants to have a confession about rising cost of supplies, but you’re hearing incessant whispering that you’re not sure where they’re coming from and quickly excuse yourself.</eventText>
@@ -426,7 +428,7 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				<prominence id="insanityTheme">3</prominence>
 			</functionalDescription>
 		</storyNode>
-		
+
 		<storyNode id="nightwatchMystery" type="satellite" lastNode="false">
 			<teaserText>A defender of the city visits.</teaserText>
 			<eventText>Night watch wants you to stand watch with him because he’s heard rumors of vampires in the area.</eventText>
@@ -434,9 +436,9 @@ They share an uproarious laugh over what they imagined got him into that state.<
 				<prominence id="insanityTheme">1</prominence>
 			</functionalDescription>
 		</storyNode>
-		
 
-	    
+
+
 	    <!-- ~~KERNELS~~ -->
 
 
@@ -448,29 +450,29 @@ They share an uproarious laugh over what they imagined got him into that state.<
 			</functionalDescription>
 	        <prerequisite>
 
-	        </prerequisite>     
+	        </prerequisite>
 	    </storyNode>
 
 		<storyNode id="summerKernel" type="kernel" lastNode="false">
-          	<teaserText>...</teaserText>        	
+          	<teaserText>...</teaserText>
          	<eventText>The sun beats down on you, almost physically forcing the sweat from your body. The plains surrounding you are seemingly infinite in their vastness, matched only by the great pure azure hanging above. A gust of wind toys with the sea of tall grass, and suddenly you are granted a glimpse at the things that could be, the things that will be, and even some things that might’ve been. Cities rise from the ground, their cobbled streets and shingled rooves willed into being by the sheer strength of your devotion to the divine majesty with which you commune. This wonder can persist, can withstand the test of time—all you need to do is spread the word, live in accordance with the tenants you have been shown. Most of all, though, you must never, ever doubt, never waver. Even the most steadfast of citadels will crumble, if the foundation is not sound.</eventText>
 			<functionalDescription>
 
 			</functionalDescription>
 	        <prerequisite>
-	            <sceneReq name="springKernel" operator="seen"/>         
-	        </prerequisite>      
+	            <sceneReq name="springKernel" operator="seen"/>
+	        </prerequisite>
 	    </storyNode>
 
 		<storyNode id="fallKernel" type="kernel" lastNode="true">
-         	<teaserText>...</teaserText>			
+         	<teaserText>...</teaserText>
          	<eventText>A chill wind rips through the air, biting at exposed skin and tearing leaves from where they perch. The trees know that the time for sleep is near, and the conflagration of oranges, reds and yellows they display mark their final arboreal celebration. The husks of dead leaves slither and rustle along the ground, just the first to fall in the cold months ahead. This flame that was entrusted to you, you have succeeded in tending to it, nurturing it from a mere spark to the roaring bonfire it is today. The fierce dread of winter marches ever closer, though, brining with it the numbing frost and frigid death it is best known for—will your fire burn bright enough to wait out this creeping season? When the snow finally begins to melt, and the streams swell with mountain run-off, what will remain of what you have done? Will it persist?</eventText>
 			<functionalDescription>
 
 			</functionalDescription>
 	        <prerequisite>
-	            <sceneReq name="summerKernel" operator="seen"/>         
-	        </prerequisite>      
+	            <sceneReq name="summerKernel" operator="seen"/>
+	        </prerequisite>
 	    </storyNode>
 	</storyNodes>
 

--- a/src/game/StoryExplorerGame.java
+++ b/src/game/StoryExplorerGame.java
@@ -91,17 +91,19 @@ public abstract class StoryExplorerGame
 		return textList;
 	}
 	
-	public ArrayList<String> getSatellitesTeaserImage()
+	public ArrayList<String> getSatellitesTeaserImages()
 	{
 		ArrayList<String> imageList = new ArrayList<String>();
 		
 		for (StoryNode s : m_currentSatellites)
 		{
-			if (s.getTeaserImage() == null) {
+			if (s.getTeaserImage() == null) 
+			{
 				imageList.add("");
 				
 			}
-			else {
+			else 
+			{
 				imageList.add(s.getTeaserImage());
 			}
 			

--- a/src/game/StoryExplorerGame.java
+++ b/src/game/StoryExplorerGame.java
@@ -91,6 +91,25 @@ public abstract class StoryExplorerGame
 		return textList;
 	}
 	
+	public ArrayList<String> getSatellitesTeaserImage()
+	{
+		ArrayList<String> imageList = new ArrayList<String>();
+		
+		for (StoryNode s : m_currentSatellites)
+		{
+			if (s.getTeaserImage() == null) {
+				imageList.add("");
+				
+			}
+			else {
+				imageList.add(s.getTeaserImage());
+			}
+			
+		}
+		
+		return imageList;
+	}
+	
 	public void consumeSatellite(int index)
 	{
 		if (index < 0 || index >= m_currentSatellites.size())

--- a/src/game/ui/SatelliteChoices.java
+++ b/src/game/ui/SatelliteChoices.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import game.StoryExplorerGame;
 import processing.core.PApplet;
 import processing.core.PFont;
+import processing.core.PImage;
 
 public class SatelliteChoices
 {
@@ -104,6 +105,8 @@ public class SatelliteChoices
 		m_parent.textAlign(PApplet.CENTER, PApplet.CENTER);
 		
 		ArrayList<String> teaserText = m_game.getSatellitesTeaserText();
+		ArrayList<String> teaserImage = m_game.getSatellitesTeaserImage();
+
 		int numButtons = Math.min(teaserText.size(), m_buttons.length);
 		
 		for (int buttonNum=0; buttonNum < numButtons; buttonNum++)
@@ -126,19 +129,18 @@ public class SatelliteChoices
 			m_parent.strokeWeight(BUTTON_STROKE_WEIGHT);
 			
 			m_parent.rect(button.x, button.y, button.width, button.height, 7);
-			
-			///
-			// Button text
-
 			m_parent.fill(0);
-			
-			m_parent.text(teaserText.get(buttonNum),
+			///
+			// Button text or image
+			if (!teaserImage.get(buttonNum).isEmpty()) {
+				PImage img = m_parent.loadImage(teaserImage.get(buttonNum));
+				img.resize(0, BUTTON_HEIGHT);
+				m_parent.image(img, button.x + (button.width / 8), button.y + (button.height/2));
+			}
+				m_parent.text(teaserText.get(buttonNum),
 					      button.x + BUTTON_TEXT_PADDING, button.y + BUTTON_TEXT_PADDING, 
 					      button.width - 2*BUTTON_TEXT_PADDING, button.height - 2*BUTTON_TEXT_PADDING);
-
-		}
-		
-		
+		}	
 	}
 	
 	///////////////////////////

--- a/src/game/ui/SatelliteChoices.java
+++ b/src/game/ui/SatelliteChoices.java
@@ -105,7 +105,7 @@ public class SatelliteChoices
 		m_parent.textAlign(PApplet.CENTER, PApplet.CENTER);
 		
 		ArrayList<String> teaserText = m_game.getSatellitesTeaserText();
-		ArrayList<String> teaserImage = m_game.getSatellitesTeaserImage();
+		ArrayList<String> teaserImage = m_game.getSatellitesTeaserImages();
 
 		int numButtons = Math.min(teaserText.size(), m_buttons.length);
 		

--- a/src/storyEngine/storyNodes/StoryNode.java
+++ b/src/storyEngine/storyNodes/StoryNode.java
@@ -31,6 +31,9 @@ public class StoryNode
 
 	@Element(name="teaserText")
 	protected String m_teaserText;
+	
+	@Element(name="teaserImage", required=false)
+	protected String m_teaserImage;
 
 	@Element(name="eventText")
 	protected String m_eventText;
@@ -51,11 +54,12 @@ public class StoryNode
 			@Attribute(name="id") String id, 
 			@Attribute(name="type") NodeType type,
 			@Element(name="teaserText") String teaserText, 
+			@Element(name="teaserImage") String teaserImage, 
 			@Element(name="eventText") String eventText,
 			@Element(name="functionalDescription") FunctionalDescription funcDesc,
 			@ElementList(name="choices", inline=true) ArrayList<Choice> choices)
 	{
-		this(id, type, false, teaserText, eventText, funcDesc, null, choices);
+		this(id, type, false, teaserText, teaserImage, eventText, funcDesc, null, choices);
 	}
 	
 	
@@ -63,12 +67,13 @@ public class StoryNode
 			@Attribute(name="id") String id,  
 			@Attribute(name="type") NodeType type,
 			@Element(name="teaserText") String teaserText, 
+			@Element(name="teaserImage", required=false) String teaserImage, 
 			@Element(name="eventText") String eventText,
 			@Element(name="functionalDescription") FunctionalDescription funcDesc,
 			@Element(name="prerequisite", required=false) Prerequisite prerequisite,
 			@ElementList(name="choices", inline=true) ArrayList<Choice> choices)
 	{
-		this(id, type, false, teaserText, eventText, funcDesc, prerequisite, choices);
+		this(id, type, false, teaserText, teaserImage, eventText, funcDesc, prerequisite, choices);
 	}
 
 
@@ -76,7 +81,8 @@ public class StoryNode
 			@Attribute(name="id") String id,  
 			@Attribute(name="type") NodeType type,
 			@Attribute(name="lastNode", required=false) boolean lastNode,
-			@Element(name="teaserText") String teaserText, 
+			@Element(name="teaserText", required=false) String teaserText, 
+			@Element(name="teaserImage", required=false) String teaserImage, 
 			@Element(name="eventText") String eventText,
 			@Element(name="functionalDescription") FunctionalDescription funcDesc,
 			@Element(name="prerequisite", required=false) Prerequisite prerequisite,
@@ -86,6 +92,7 @@ public class StoryNode
 		m_type = type;
 		m_lastNode = false;
 		m_teaserText = teaserText;
+		m_teaserImage = teaserImage;
 		m_eventText = eventText;
 		m_functionalDesc = funcDesc;
 		m_prerequisite = prerequisite;
@@ -97,6 +104,7 @@ public class StoryNode
 
 	public String getID() { return m_id; }
 	public String getTeaserText() { return m_teaserText; }
+	public String getTeaserImage() { return m_teaserImage; }
 	public String getEventText() { return m_eventText; }
 	
 	public boolean isLastNode() { return m_lastNode; }

--- a/src/storyEngine/storyNodes/StoryNode.java
+++ b/src/storyEngine/storyNodes/StoryNode.java
@@ -54,7 +54,7 @@ public class StoryNode
 			@Attribute(name="id") String id, 
 			@Attribute(name="type") NodeType type,
 			@Element(name="teaserText") String teaserText, 
-			@Element(name="teaserImage") String teaserImage, 
+			@Element(name="teaserImage", required=false) String teaserImage, 
 			@Element(name="eventText") String eventText,
 			@Element(name="functionalDescription") FunctionalDescription funcDesc,
 			@ElementList(name="choices", inline=true) ArrayList<Choice> choices)


### PR DESCRIPTION
First shot at addressing https://github.com/sansbrina/storyexplorer/issues/1, which is to allow images instead of text for teaser text choices.

Adds a new element on the nodes for the path to the teaserImage, and loads it if the path is present.