### PR TITLE
Global rules

### DIFF
--- a/src/storyEngine/GlobalRule.java
+++ b/src/storyEngine/GlobalRule.java
@@ -72,7 +72,7 @@ public class GlobalRule
 		this(null, null, storyStateFilter, nodesAffectedFilter);
 	}
 	
-	//
+	////
 	
 	public boolean appliesToNode(StoryNode node)
 	{
@@ -81,10 +81,22 @@ public class GlobalRule
 	
 	public boolean passes(StoryState storyState)
 	{
-		return true;//TODO: global rule passes?
+		boolean passes = true;
+		
+		if (m_nodeFilter != null && !m_nodeFilter.passes(storyState))
+		{
+			passes = false;
+		}
+		
+		if (m_storyStateFilter != null && m_storyStateFilter.passes(storyState))
+		{
+			passes = false;
+		}
+		
+		return passes;
 	}
 	
-	//
+	////
 	
 	public boolean isValid()
 	{
@@ -113,7 +125,7 @@ public class GlobalRule
 		return valid;
 	}
 	
-	//
+	////
 	
 	public String toString()
 	{
@@ -235,7 +247,7 @@ public class GlobalRule
 		}
 	}
 	
-	//
+	////
 	
 	public static class StoryStateFilter
 	{
@@ -310,7 +322,7 @@ public class GlobalRule
 		}
 	}
 	
-	// 
+	////
 	
 	public static class NodesAffected
 	{	

--- a/src/storyEngine/GlobalRule.java
+++ b/src/storyEngine/GlobalRule.java
@@ -1,0 +1,242 @@
+package storyEngine;
+
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+
+public class GlobalRule
+{	
+	public static enum HowMany { allOf, anyOf }
+	public static enum ListTypeForNodes { tags, storyElements, nodeIDs }
+	public static enum NodeState { seen, notSeen }
+	public static enum TagState { present, notPresent }
+	
+	@Attribute(name="id", required=false)
+	protected String m_id;
+	
+	//
+	
+	@Element(name="nodeFilter", required=false)
+	protected NodeFilter m_nodeFilter;
+	
+	@Element(name="storyStateFilter", required=false)
+	protected StoryStateFilter m_storyStateFilter;
+	
+	//
+	
+	@Element(name="nodesAffected")
+	protected NodesAffected m_nodesAffectedFilter;
+	
+	///////////////////////////////////////////
+	
+	protected GlobalRule(
+			@Attribute(name="id", required=false) String id,
+			@Element(name="nodeFilter", required=false) NodeFilter nodeFilter,
+			@Element(name="storyStateFilter", required=false) StoryStateFilter storyStateFilter,
+			@Element(name="nodesAffected") NodesAffected nodesAffectedFilter)
+	{
+		m_id = id;
+		m_nodeFilter = nodeFilter;
+		m_storyStateFilter = storyStateFilter;
+		m_nodesAffectedFilter = nodesAffectedFilter;
+	}
+	
+	public GlobalRule(
+			@Attribute(name="id", required=false) String id,
+			@Element(name="nodeFilter", required=false) NodeFilter nodeFilter,
+			@Element(name="nodesAffected") NodesAffected nodesAffectedFilter)
+	{
+		this(id, nodeFilter, null, nodesAffectedFilter);
+	}
+	
+	public GlobalRule(
+			@Attribute(name="id", required=false) String id,
+			@Element(name="storyStateFilter", required=false) StoryStateFilter storyStateFilter,
+			@Element(name="nodesAffected") NodesAffected nodesAffectedFilter)
+	{
+		this(id, null, storyStateFilter, nodesAffectedFilter);
+	}
+	
+	public GlobalRule(
+			@Element(name="nodeFilter", required=false) NodeFilter nodeFilter,
+			@Element(name="nodesAffected") NodesAffected nodesAffectedFilter)
+	{
+		this(null, nodeFilter, null, nodesAffectedFilter);
+	}
+	
+	public GlobalRule(
+			@Element(name="storyStateFilter", required=false) StoryStateFilter storyStateFilter,
+			@Element(name="nodesAffected") NodesAffected nodesAffectedFilter)
+	{
+		this(null, null, storyStateFilter, nodesAffectedFilter);
+	}
+	
+	//
+	
+	public boolean isValid()
+	{
+		boolean valid = true;
+		
+		if (m_nodeFilter == null && m_storyStateFilter == null)
+		{
+			valid = false;
+		}
+		
+		if (m_nodeFilter != null && !m_nodeFilter.isValid())
+		{
+			valid = false;
+		}
+		
+		if (m_storyStateFilter != null && !m_storyStateFilter.isValid())
+		{
+			valid = false;
+		}
+		
+		if (m_nodesAffectedFilter == null || !m_nodesAffectedFilter.isValid())
+		{
+			valid = false;
+		}
+		
+		return valid;
+	}
+	
+	//
+	
+	public String toString()
+	{
+		String result = "";
+		
+		result += "Global rule";
+		if (m_id != null && !m_id.isEmpty())
+		{
+			result += " with id " + m_id;
+		}
+		result += ":";
+		
+		if (m_nodeFilter != null)
+		{
+			result += "\n" + m_nodeFilter;
+		}
+		else if (m_storyStateFilter != null)
+		{
+			result += "\n" + m_storyStateFilter;
+		}
+		
+		result += "\n" + m_nodesAffectedFilter;
+		
+		return result;
+	}
+	
+	///////////////////////////////////////////
+	
+	public static class NodeFilter
+	{	
+		@Attribute(name="checkNodesUsing")
+		protected ListTypeForNodes m_filterNodeListType;
+		
+		@Attribute(name="listToCheck")
+		protected String m_itemList; // needs to be comma-delimited list
+		
+		@Attribute(name="howManyRequired")
+		protected HowMany m_howManyItemsRequired;
+		
+		@Attribute(name="nodeState")
+		protected NodeState m_nodeState;
+		
+		public NodeFilter(
+				@Attribute(name="checkNodesUsing") ListTypeForNodes filterNodeListType,
+				@Attribute(name="listToCheck") String itemList,
+				@Attribute(name="howManyRequired") HowMany howManyItemsRequired,
+				@Attribute(name="nodeState") NodeState nodeState)
+		{
+			m_filterNodeListType = filterNodeListType;
+			m_itemList = itemList;
+			m_howManyItemsRequired = howManyItemsRequired;
+			m_nodeState = nodeState;
+		}
+		
+		public boolean isValid()
+		{
+			return m_itemList.split(",").length > 0;
+		}
+		
+		public String toString()
+		{
+			return "\tChecking whether " + m_howManyItemsRequired
+					+ " list of type " + m_filterNodeListType 
+					+ " has been " + m_nodeState + ": "
+					+ m_itemList.replaceAll(",", " ");
+		}
+	}
+	
+	//
+	
+	public static class StoryStateFilter
+	{
+		@Attribute(name="tagsToCheck")
+		protected String m_tagList; // needs to be comma-delimited list
+		
+		@Attribute(name="howManyRequired")
+		protected HowMany m_howManyItemsRequired;
+		
+		@Attribute(name="tagState")
+		protected TagState m_tagState;
+		
+		public StoryStateFilter(
+				@Attribute(name="tagsToCheck")  String tagList,
+				@Attribute(name="howManyRequired") HowMany howManyItemsRequired,
+				@Attribute(name="tagState") TagState tagState)
+		{
+			m_tagList = tagList;
+			m_howManyItemsRequired = howManyItemsRequired;
+			m_tagState = tagState;
+		}
+		
+		public boolean isValid()
+		{
+			return m_tagList.split(",").length > 0;
+		}
+		
+		public String toString()
+		{
+			return "\tChecking whether " + m_howManyItemsRequired
+					+ " tags are " + m_tagState + " in story state: "
+					+ m_tagList.replaceAll(",", " ");
+		}
+	}
+	
+	// 
+	
+	public static class NodesAffected
+	{	
+		@Attribute(name="checkNodesUsing")
+		protected ListTypeForNodes m_filterNodeListType;
+		
+		@Attribute(name="listToCheck")
+		protected String m_itemList; // needs to be comma-delimited list
+		
+		@Attribute(name="howManyRequired")
+		protected HowMany m_howManyItemsRequired;
+		
+		public NodesAffected(
+				@Attribute(name="checkNodesUsing") ListTypeForNodes filterNodeListType,
+				@Attribute(name="listToCheck") String itemList,
+				@Attribute(name="howManyRequired") HowMany howManyItemsRequired)
+		{
+			m_filterNodeListType = filterNodeListType;
+			m_itemList = itemList;
+			m_howManyItemsRequired = howManyItemsRequired;
+		}
+		
+		public boolean isValid()
+		{
+			return m_itemList.split(",").length > 0;
+		}
+		
+		public String toString()
+		{
+			return "\tNodes the rule applies to include those that have " + m_howManyItemsRequired
+					+ " the list of type " + m_filterNodeListType + ": "
+					+ m_itemList.replaceAll(",", " ");
+		}
+	}
+}

--- a/src/storyEngine/Story.java
+++ b/src/storyEngine/Story.java
@@ -401,10 +401,10 @@ public class Story
 		for (StoryNode node : m_nodes)
 		{
 			if (!node.isConsumed() 
-					&& node.passesPrerequisite(m_storyState)
-					&& node.passesGlobalRules(m_globalRules, m_storyState)
 					&& (!kernelsOnly || node.isKernel())
-					&& (!satellitesOnly || node.isSatellite()))
+					&& (!satellitesOnly || node.isSatellite())
+					&& node.passesPrerequisite(m_storyState)
+					&& node.passesGlobalRules(m_globalRules, m_storyState))
 			{
 				availableNodes.add(node);
 			}

--- a/src/storyEngine/StoryState.java
+++ b/src/storyEngine/StoryState.java
@@ -233,6 +233,22 @@ public class StoryState
 		return seenScene;
 	}
 	
+	public boolean haveSeenSceneWithFeature(String featureID)
+	{
+		boolean seenScene = false;
+		
+		for (StoryNode n : m_scenesSeen)
+		{
+			if (n.featuresElement(featureID))
+			{
+				seenScene = true;
+				break;
+			}
+		}
+		
+		return seenScene;
+	}
+	
 	float getProminenceForMostRecentNodeWithElement(String elementID)
 	{
 		float desire = -1;

--- a/src/storyEngine/StoryState.java
+++ b/src/storyEngine/StoryState.java
@@ -20,6 +20,11 @@ import storyEngine.storyNodes.StoryNode;
 // since we've seen certain themes, characters, and so on.
 // Other values like tension can also be tracked.
 
+// Currently, it is assumed that only an initial story
+// state is ever stored in XML; some changes would be
+// required if the current state of a story needed to
+// be saved to disk (e.g. to save progress).
+
 public class StoryState
 {
 	
@@ -42,6 +47,7 @@ public class StoryState
 	@ElementList(required=false, inline=true)
 	protected ArrayList<String> m_tagList;
 	
+	// List of scenes as they are seen (not stored in XML)
 	protected ArrayList<StoryNode> m_scenesSeen;
 	
 	

--- a/src/storyEngine/storyNodes/FunctionalDescription.java
+++ b/src/storyEngine/storyNodes/FunctionalDescription.java
@@ -88,6 +88,7 @@ public class FunctionalDescription
 	}
 	
 	
+	@SuppressWarnings("unlikely-arg-type")
 	boolean featuresElement(String id)
 	{
 		return (m_elementProminences.containsKey(id) || m_elementTags.contains(id));

--- a/src/storyEngine/storyNodes/Prerequisite.java
+++ b/src/storyEngine/storyNodes/Prerequisite.java
@@ -15,6 +15,8 @@ import storyEngine.storyElements.StoryElementCollection;
 // of which must pass for the prerequisite to pass.
 public class Prerequisite
 {
+	@Attribute(name="id", required=false)
+	protected String m_id;
 	
 	@ElementList(inline=true, required=false)
 	protected ArrayList<QuantifiableElementRequirement> m_quantifiableRequirements;
@@ -34,11 +36,13 @@ public class Prerequisite
 	}
 	
 	public Prerequisite(
+			@Attribute(name="id", required=false) String id, 
 			ArrayList<QuantifiableElementRequirement> qRequirements,
 			ArrayList<TagRequirement> tagRequirements,
 			ArrayList<SceneRequirement> sceneRequirements)
 	{
 		this();
+		m_id = (id == null) ? "" : id;
 		if (qRequirements != null) m_quantifiableRequirements.addAll(qRequirements);
 		if (tagRequirements != null) m_tagRequirements.addAll(tagRequirements);
 		if (sceneRequirements != null) m_sceneRequirements.addAll(sceneRequirements);

--- a/src/storyEngine/storyNodes/StoryNode.java
+++ b/src/storyEngine/storyNodes/StoryNode.java
@@ -7,6 +7,7 @@ import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
+import storyEngine.GlobalRule;
 import storyEngine.Story;
 import storyEngine.StoryState;
 import storyEngine.storyElements.StoryElementCollection;
@@ -148,6 +149,31 @@ public class StoryNode
 		else
 		{
 			return m_prerequisite.passes(storyState);
+		}
+	}
+	
+	
+	////////////////////////////////////////////////////////////////
+	
+	
+	public boolean passesGlobalRules(ArrayList<GlobalRule> rules, StoryState storyState)
+	{
+		if (rules == null || rules.isEmpty())
+		{
+			return true;
+		}
+		else
+		{
+			boolean passes = true;
+			for (GlobalRule rule : rules)
+			{
+				if (rule.appliesToNode(this) && !rule.passes(storyState))
+				{
+					passes = false;
+					break;
+				}
+			}
+			return passes;
 		}
 	}
 	

--- a/src/test/TestGlobalRules.java
+++ b/src/test/TestGlobalRules.java
@@ -1,0 +1,86 @@
+package test;
+
+import java.io.File;
+
+import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.core.Persister;
+
+import storyEngine.GlobalRule;
+import storyEngine.GlobalRule.NodeFilter;
+import storyEngine.GlobalRule.NodesAffected;
+import storyEngine.GlobalRule.StoryStateFilter;
+
+public class TestGlobalRules
+{
+	public static void main(String[] args)
+	{
+		Serializer serializer = new Persister();
+		
+		//////////////////////////////////////////////////////////////////
+		
+		NodeFilter nodeFilter = new NodeFilter(
+				GlobalRule.ListTypeForNodes.nodeIDs, 
+				"nodeID1,nodeID2,nodeID3",
+				GlobalRule.HowMany.anyOf,
+				GlobalRule.NodeState.seen);
+		
+		
+		NodesAffected nodesAffected = new NodesAffected(
+				GlobalRule.ListTypeForNodes.nodeIDs, 
+				"nodeID4",
+				GlobalRule.HowMany.allOf);
+		
+		GlobalRule nodeFilterRule = new GlobalRule("nodeFilterRule", nodeFilter, nodesAffected);
+		
+		//
+		
+		StoryStateFilter storyStateFilter = new StoryStateFilter(
+				"tag1,tag2,tag3",
+				GlobalRule.HowMany.allOf,
+				GlobalRule.TagState.notPresent);
+		
+		NodesAffected nodesAffected2 = new NodesAffected(
+				GlobalRule.ListTypeForNodes.nodeIDs, 
+				"nodeID4,nodeID5",
+				GlobalRule.HowMany.anyOf);
+		
+		GlobalRule storyStateFilterRule = new GlobalRule("storyStateFilterRule", storyStateFilter, nodesAffected);
+		
+		//////////////////////////////////////////////////////////////////
+		
+		try
+		{
+			File result = new File("./testData/testGlobalRules/testGlobalRules1a.xml");
+			serializer.write(nodeFilterRule, result);
+			
+			GlobalRule readRule = 
+					serializer.read(GlobalRule.class, result);
+			
+			System.out.println(readRule);
+			System.out.println("Valid: " + readRule.isValid());
+			
+			File result2 = new File("./testData/testGlobalRules/testGlobalRules1b.xml");
+			
+			serializer.write(readRule, result2);
+			
+			///
+			
+			result = new File("./testData/testGlobalRules/testGlobalRules2a.xml");
+			serializer.write(storyStateFilterRule, result);
+			
+			readRule = 
+					serializer.read(GlobalRule.class, result);
+			
+			System.out.println("\n\n" + readRule);
+			System.out.println("Valid: " + readRule.isValid());
+			
+			result2 = new File("./testData/testGlobalRules/testGlobalRules2b.xml");
+			
+			serializer.write(readRule, result2);
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/test/TestGlobalRules.java
+++ b/src/test/TestGlobalRules.java
@@ -1,6 +1,8 @@
 package test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.simpleframework.xml.Serializer;
 import org.simpleframework.xml.core.Persister;
@@ -9,6 +11,15 @@ import storyEngine.GlobalRule;
 import storyEngine.GlobalRule.NodeFilter;
 import storyEngine.GlobalRule.NodesAffected;
 import storyEngine.GlobalRule.StoryStateFilter;
+import storyEngine.PrioritizationType;
+import storyEngine.Story;
+import storyEngine.StoryState;
+import storyEngine.storyElements.ElementType;
+import storyEngine.storyElements.StoryElement;
+import storyEngine.storyElements.StoryElementCollection;
+import storyEngine.storyNodes.FunctionalDescription;
+import storyEngine.storyNodes.NodeType;
+import storyEngine.storyNodes.StoryNode;
 
 public class TestGlobalRules
 {
@@ -82,5 +93,31 @@ public class TestGlobalRules
 		{
 			e.printStackTrace();
 		}
+		
+		/////////////
+		
+		/////
+		// Test that nodes are correctly filtered by the global rules...
+		///
+		
+		StoryElementCollection elements = new StoryElementCollection();
+		elements.add(new StoryElement("tag1", "themes", "tag1", ElementType.taggable));
+		
+		ArrayList<String> tags = new ArrayList<String>();
+		tags.add("tag1");
+		StoryState initStoryState = new StoryState(null, null, tags);
+		
+		StoryNode node = new StoryNode("nodeID4", NodeType.kernel, "teaser text", "event text", new FunctionalDescription(), null);
+
+		Story story;
+		ArrayList<GlobalRule> globalRules;
+		
+		globalRules = new ArrayList<>(Arrays.asList(storyStateFilterRule));
+		story = new Story(5, PrioritizationType.strawManRandom, new ArrayList<>(Arrays.asList(node)), null, initStoryState, globalRules);
+		System.out.println("\n\nNodes available using story-state-filtered global rule: " + story.getAvailableKernelNodes());
+		
+		globalRules = new ArrayList<>(Arrays.asList(nodeFilterRule));
+		story = new Story(5, PrioritizationType.strawManRandom, new ArrayList<>(Arrays.asList(node)), null, initStoryState, globalRules);
+		System.out.println("\n\nNodes available using node-filtered global rule: " + story.getAvailableKernelNodes());
 	}
 }

--- a/src/test/TestGlobalRules.java
+++ b/src/test/TestGlobalRules.java
@@ -44,7 +44,7 @@ public class TestGlobalRules
 				"nodeID4,nodeID5",
 				GlobalRule.HowMany.anyOf);
 		
-		GlobalRule storyStateFilterRule = new GlobalRule("storyStateFilterRule", storyStateFilter, nodesAffected);
+		GlobalRule storyStateFilterRule = new GlobalRule("storyStateFilterRule", storyStateFilter, nodesAffected2);
 		
 		//////////////////////////////////////////////////////////////////
 		

--- a/testData/testGlobalRules/testGlobalRules1a.xml
+++ b/testData/testGlobalRules/testGlobalRules1a.xml
@@ -1,0 +1,4 @@
+<globalRule id="nodeFilterRule">
+   <nodeFilter checkNodesUsing="nodeIDs" listToCheck="nodeID1,nodeID2,nodeID3" howManyRequired="anyOf" nodeState="seen"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+</globalRule>

--- a/testData/testGlobalRules/testGlobalRules1b.xml
+++ b/testData/testGlobalRules/testGlobalRules1b.xml
@@ -1,0 +1,4 @@
+<globalRule id="nodeFilterRule">
+   <nodeFilter checkNodesUsing="nodeIDs" listToCheck="nodeID1,nodeID2,nodeID3" howManyRequired="anyOf" nodeState="seen"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+</globalRule>

--- a/testData/testGlobalRules/testGlobalRules2a.xml
+++ b/testData/testGlobalRules/testGlobalRules2a.xml
@@ -1,4 +1,4 @@
 <globalRule id="storyStateFilterRule">
    <storyStateFilter tagsToCheck="tag1,tag2,tag3" howManyRequired="allOf" tagState="notPresent"/>
-   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4,nodeID5" howManyRequired="anyOf"/>
 </globalRule>

--- a/testData/testGlobalRules/testGlobalRules2a.xml
+++ b/testData/testGlobalRules/testGlobalRules2a.xml
@@ -1,0 +1,4 @@
+<globalRule id="storyStateFilterRule">
+   <storyStateFilter tagsToCheck="tag1,tag2,tag3" howManyRequired="allOf" tagState="notPresent"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+</globalRule>

--- a/testData/testGlobalRules/testGlobalRules2b.xml
+++ b/testData/testGlobalRules/testGlobalRules2b.xml
@@ -1,4 +1,4 @@
 <globalRule id="storyStateFilterRule">
    <storyStateFilter tagsToCheck="tag1,tag2,tag3" howManyRequired="allOf" tagState="notPresent"/>
-   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4,nodeID5" howManyRequired="anyOf"/>
 </globalRule>

--- a/testData/testGlobalRules/testGlobalRules2b.xml
+++ b/testData/testGlobalRules/testGlobalRules2b.xml
@@ -1,0 +1,4 @@
+<globalRule id="storyStateFilterRule">
+   <storyStateFilter tagsToCheck="tag1,tag2,tag3" howManyRequired="allOf" tagState="notPresent"/>
+   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
+</globalRule>

--- a/testData/testSimpleXML/testSimple.xml
+++ b/testData/testSimpleXML/testSimple.xml
@@ -1,4 +1,4 @@
-<story numTopScenesForUser="5" prioritizationType="physicsForcesAnalogy">
+<story numTopScenesForUser="5" prioritizationType="sumOfCategoryMaximums">
    <storyNodes>
       <storyNode id="node1" type="kernel" lastNode="false">
          <teaserText>node 1 teaser</teaserText>
@@ -10,7 +10,7 @@
       </storyNode>
       <storyNode id="node2" type="kernel" lastNode="false">
          <teaserText>node 2 teaser</teaserText>
-         <eventText>node 3 event</eventText>
+         <eventText>node 2 event</eventText>
          <functionalDescription>
             <prominence id="dawgCharacter">3</prominence>
             <tag id="sunnyWeather"/>

--- a/testData/testSimpleXML/testSimple2.xml
+++ b/testData/testSimpleXML/testSimple2.xml
@@ -1,4 +1,4 @@
-<story numTopScenesForUser="5" prioritizationType="physicsForcesAnalogy">
+<story numTopScenesForUser="5" prioritizationType="sumOfCategoryMaximums">
    <storyNodes>
       <storyNode id="node1" type="kernel" lastNode="false">
          <teaserText>node 1 teaser</teaserText>
@@ -10,7 +10,7 @@
       </storyNode>
       <storyNode id="node2" type="kernel" lastNode="false">
          <teaserText>node 2 teaser</teaserText>
-         <eventText>node 3 event</eventText>
+         <eventText>node 2 event</eventText>
          <functionalDescription>
             <prominence id="dawgCharacter">3</prominence>
             <tag id="sunnyWeather"/>


### PR DESCRIPTION
Implemented global rules that should make certain kinds of prerequisites that apply to many story nodes less tedious to set up.

A list of node IDs is used to determine what nodes the rule should apply to. There are two different kinds of rules. One checks that some or all of a list of nodes has been seen or not seen. The other checks information in the story state.

An example of the node filter rule type in XML:

```
<globalRule id="nodeFilterRule">
   <nodeFilter checkNodesUsing="nodeIDs" listToCheck="nodeID1,nodeID2,nodeID3" howManyRequired="anyOf" nodeState="seen"/>
   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4" howManyRequired="allOf"/>
</globalRule>
```

Corresponding `toString`:

```
Global rule with id nodeFilterRule:
	Checking whether anyOf list of type nodeIDs has been seen: nodeID1 nodeID2 nodeID3
	Nodes the rule applies to include those that have allOf the list of type nodeIDs: nodeID4
```

An example of the story filter rule type in XML:

```
<globalRule id="storyStateFilterRule">
   <storyStateFilter tagsToCheck="tag1,tag2,tag3" howManyRequired="allOf" tagState="notPresent"/>
   <nodesAffected checkNodesUsing="nodeIDs" listToCheck="nodeID4,nodeID5" howManyRequired="anyOf"/>
</globalRule>
```

Corresponding `toString`:

```
Global rule with id storyStateFilterRule:
	Checking whether allOf tags are notPresent in story state: tag1 tag2 tag3
	Nodes the rule applies to include those that have anyOf the list of type nodeIDs: nodeID4 nodeID5
```